### PR TITLE
Remove hard-coded `bodyLimit`,  defer to underlying implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ export async function wrappedTurbo(args) {
 ### Increasing the allowed size of uploaded assets
 
 In your local / ci env set the `BODY_LIMIT` environment variable.
-The value is measure in bytes.
+The value is measured in bytes.
 
 e.g.:
 ```bash

--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ export async function wrappedTurbo(args) {
 }
 ```
 
+### Increasing the allowed size of uploaded assets
+
+In your local / ci env set the `BODY_LIMIT` environment variable.
+The value is measure in bytes.
+
+e.g.:
+```bash
+BODY_LIMIT=1048576 # 1 MB (fastify default, 1024^2)
+BODY_LIMIT=536870912 # 512 MB (1024^2 * 512)
+BODY_LIMIT=1073741824 # 1 GB (1024^3)
+```
+
 ## Debugging
 
 This project stores files in `<git root>/node_modules/.turbo-daemon/`

--- a/src/daemon/start-app.js
+++ b/src/daemon/start-app.js
@@ -10,7 +10,7 @@ import getPort from 'get-port';
 import { createApp } from 'turborepo-remote-cache';
 
 import { pidFilePath } from '../shared.js';
-import { cleanup, fileLogger, ONE_HUNDRED_MB, pidFile, THIRTY_MINUTES } from './setup.js';
+import { cleanup, fileLogger, pidFile, THIRTY_MINUTES } from './setup.js';
 
 /** @type {ReturnType<typeof setTimeout>} */
 let exitTimer;
@@ -33,12 +33,6 @@ for (const [key, value] of storageEnv) {
  * https://github.com/ducktors/turborepo-remote-cache/blob/main/src/index.ts
  */
 const fastifyApp = createApp({
-  /**
-   * Default is 50MB (for turborepo-remote-cache) and 1MB (for fastify)
-   * we have some very large assets.
-   */
-  bodyLimit: ONE_HUNDRED_MB,
-
   /**
    * Allows us to debug, since, as a daemon, we won't have access to stdout/stderr
    * (default logger logs to stdout/stderr)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": ["@tsconfig/node22", "@tsconfig/strictest"],
-  "includes": ["src/**/*"],
   "compilerOptions": {
     "incremental": true,
     "module": "Node16",


### PR DESCRIPTION
Closes #15, #14

Of note, if all you need is to configure the body limit,
you can set the env var, `BODY_LIMIT` (does not need to be handled by turbo-daemon): 

Here is the default implementation:
https://github.com/ducktors/turborepo-remote-cache/blob/80647ee47e43921315bf1a229786566667e1dc7b/src/index.ts#L10

It's 1MB -- so _most_ folks may want to set a `BODY_LIMIT` env var on large projects.